### PR TITLE
Only retrieve the most recent workflow run for dashboard purposes

### DIFF
--- a/frontend/src/routes/actions-dashboard.tsx
+++ b/frontend/src/routes/actions-dashboard.tsx
@@ -45,9 +45,17 @@ const loadRepositories = async () => {
         const workflowRunsbyWorkflow = workflowRuns.results.filter(
           (run) => run.workflow === workflow.node_id
         );
+        const mostRecentRun = workflowRunsbyWorkflow.reduce(
+          (latest, current) => {
+            return new Date(current.updated_at) > new Date(latest.updated_at)
+              ? current
+              : latest;
+          },
+          workflowRunsbyWorkflow[0] || null
+        );
         return {
           ...workflow,
-          runs: workflowRunsbyWorkflow,
+          runs: [mostRecentRun],
         };
       }
     );


### PR DESCRIPTION
Currently, the dashboard shows _all_ workflow runs, which makes it looks like some actions are failing. This PR makes it so only the most recent actions run is used in the dashboard.