### PR TITLE
Fix navbar rendering issues

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,13 +1,13 @@
 import DarkModeSwitch from "./DarkModeSwitch";
 import GitHub from "./ui/GitHubMark";
-import { Link } from "@tanstack/react-router";
-import { useWidth } from "~/hooks/useWindowSize";
+import { Link, useLocation } from "@tanstack/react-router";
 import { Popover } from "radix-ui";
 import { MenuIcon, HomeIcon } from "lucide-react";
 import { Route as ProjectsRoute } from "~/routes/projects.index";
 import { Route as BlogRoute } from "~/routes/blog.index";
 import { Route as AboutRoute } from "~/routes/about";
 import { cn } from "~/utils/utils";
+import { useEffect, useState } from "react";
 
 export interface NavbarProps {
   height: string;
@@ -37,16 +37,72 @@ const navStyles = {
 };
 
 export default function Navbar() {
-  const { width } = useWidth();
+  const [isOpen, setIsOpen] = useState(false);
+  const pathname = useLocation().pathname;
+
+  useEffect(() => {
+    setIsOpen(false);
+  }, [pathname]);
+
   return (
     <div className={navStyles.container}>
-      {width >= 768 ? (
-        <nav
-          className={cn(
-            navStyles.nav,
-            "justify-between grid px-5 grid-cols-3 max-w-6xl"
-          )}
+      <nav
+        className={cn(
+          navStyles.nav,
+          "justify-between px-5 grid-cols-3 max-w-6xl hidden md:grid"
+        )}
+      >
+        <Link
+          to="/"
+          activeProps={{ className: navStyles.active }}
+          inactiveProps={{ className: navStyles.inactive }}
+          activeOptions={{ exact: true }}
+          className="flex cursor-pointer items-center justify-center px-1 py-0 m-0 size-[3rem] rounded-full bg-transparent shadow-none border-solid focus-visible:ring-1 focus-visible:ring-blue-500 hover:bg-gray-600/20"
+          resetScroll
+          aria-label="Home page link"
         >
+          <HomeIcon className="p-0" size={32} aria-label="Home icon" />
+        </Link>
+        <div className="align-middle grow-0 flex px-5">
+          <Link
+            to={BlogRoute.to}
+            activeProps={{ className: navStyles.active }}
+            inactiveProps={{ className: navStyles.inactive }}
+            className={navStyles.button}
+            resetScroll
+          >
+            Blog
+          </Link>
+          <Link
+            to={ProjectsRoute.to}
+            activeProps={{ className: navStyles.active }}
+            inactiveProps={{ className: navStyles.inactive }}
+            className={navStyles.button}
+            resetScroll
+          >
+            Projects
+          </Link>
+          <Link
+            to={AboutRoute.to}
+            activeProps={{ className: navStyles.active }}
+            inactiveProps={{ className: navStyles.inactive }}
+            className={navStyles.button}
+            resetScroll
+          >
+            About
+          </Link>
+        </div>
+        <div className="flex items-center justify-end grow-0">
+          <div className="px-2">
+            <GitHub githubLink={"https://github.com/andrew-s28/"} />
+          </div>
+          <div className="px-2">
+            <DarkModeSwitch />
+          </div>
+        </div>
+      </nav>
+      <nav className={cn(navStyles.nav, "flex justify-center md:hidden")}>
+        <div className="flex items-center justify-between w-full px-2">
           <Link
             to="/"
             activeProps={{ className: navStyles.active }}
@@ -54,125 +110,72 @@ export default function Navbar() {
             activeOptions={{ exact: true }}
             className="flex cursor-pointer items-center justify-center px-1 py-0 m-0 size-[3rem] rounded-full bg-transparent shadow-none border-solid focus-visible:ring-1 focus-visible:ring-blue-500 hover:bg-gray-600/20"
             resetScroll
-            aria-label="Home page link"
           >
-            <HomeIcon className="p-0" size={32} aria-label="Home icon" />
+            <HomeIcon className="p-0" size={32} />
           </Link>
-          <div className="align-middle grow-0 flex px-5">
-            <Link
-              to={BlogRoute.to}
-              activeProps={{ className: navStyles.active }}
-              inactiveProps={{ className: navStyles.inactive }}
-              className={navStyles.button}
-              resetScroll
-            >
-              Blog
-            </Link>
-            <Link
-              to={ProjectsRoute.to}
-              activeProps={{ className: navStyles.active }}
-              inactiveProps={{ className: navStyles.inactive }}
-              className={navStyles.button}
-              resetScroll
-            >
-              Projects
-            </Link>
-            <Link
-              to={AboutRoute.to}
-              activeProps={{ className: navStyles.active }}
-              inactiveProps={{ className: navStyles.inactive }}
-              className={navStyles.button}
-              resetScroll
-            >
-              About
-            </Link>
-          </div>
-          <div className="flex items-center justify-end grow-0">
-            <div className="px-2">
-              <GitHub githubLink={"https://github.com/andrew-s28/"} />
-            </div>
-            <div className="px-2">
-              <DarkModeSwitch />
-            </div>
-          </div>
-        </nav>
-      ) : (
-        <nav className={cn(navStyles.nav, "flex justify-center")}>
-          <div className="flex items-center justify-between w-full px-2">
-            <Link
-              to="/"
-              activeProps={{ className: navStyles.active }}
-              inactiveProps={{ className: navStyles.inactive }}
-              activeOptions={{ exact: true }}
-              className="flex cursor-pointer items-center justify-center px-1 py-0 m-0 size-[3rem] rounded-full bg-transparent shadow-none border-solid focus-visible:ring-1 focus-visible:ring-blue-500 hover:bg-gray-600/20"
-              resetScroll
-            >
-              <HomeIcon className="p-0" size={32} />
-            </Link>
 
-            <div className="align-middle justify-center grow-0 px-4">
-              <Popover.Root>
-                <Popover.Trigger className="flex items-center justify-center h-full cursor-pointer outline-0 focus-visible:ring-1 focus-visible:ring-blue-500">
-                  <div className="flex items-center justify-center h-full cursor-pointer outline-0 focus-visible:ring-1 focus-visible:ring-blue-500">
-                    <MenuIcon className="w-full" size={32} />
-                    <span className="sr-only">Toggle menu</span>
-                  </div>
-                </Popover.Trigger>
-                <Popover.Portal>
-                  <Popover.Content
-                    className="w-64 bg-dawn-pink-100 dark:bg-night-sky-950 p-2 rounded-lg shadow-xl z-50 border-night-sky-950 dark:border-dawn-pink-100 border-2"
-                    sideOffset={5}
-                  >
-                    <div className="flex flex-col space-y-1">
-                      <Link
-                        to={BlogRoute.to}
-                        className="px-4 py-2 hover:bg-muted rounded-md text-center"
-                        activeProps={{
-                          className:
-                            "font-bold bg-dawn-pink-300 dark:bg-night-sky-900",
-                        }}
-                        resetScroll
-                      >
-                        Blog
-                      </Link>
-                      <Link
-                        to={ProjectsRoute.to}
-                        className="px-4 py-2 hover:bg-muted rounded-md text-center"
-                        activeProps={{
-                          className:
-                            "font-bold bg-dawn-pink-300 dark:bg-night-sky-900",
-                        }}
-                        resetScroll
-                      >
-                        Projects
-                      </Link>
-                      <Link
-                        to={AboutRoute.to}
-                        className="px-4 py-2 hover:bg-muted rounded-md text-center"
-                        activeProps={{
-                          className:
-                            "font-bold bg-dawn-pink-300 dark:bg-night-sky-900",
-                        }}
-                        resetScroll
-                      >
-                        About
-                      </Link>
-                      <div className="px-2 flex items-center justify-center">
-                        <GitHub githubLink={"https://github.com/andrew-s28/"} />
-                        <DarkModeSwitch />
-                      </div>
+          <div className="align-middle justify-center grow-0 px-4">
+            <Popover.Root open={isOpen} onOpenChange={setIsOpen}>
+              <Popover.Trigger className="flex items-center justify-center h-full cursor-pointer outline-0 focus-visible:ring-1 focus-visible:ring-blue-500">
+                <div className="flex items-center justify-center h-full cursor-pointer outline-0 focus-visible:ring-1 focus-visible:ring-blue-500">
+                  <MenuIcon className="w-full" size={32} />
+                  <span className="sr-only">Toggle menu</span>
+                </div>
+              </Popover.Trigger>
+              <Popover.Portal>
+                <Popover.Content
+                  className="w-64 bg-dawn-pink-100 dark:bg-night-sky-950 p-2 rounded-lg shadow-xl z-50 border-night-sky-950 dark:border-dawn-pink-100 border-2"
+                  sideOffset={5}
+                >
+                  <div className="flex flex-col space-y-1">
+                    <Link
+                      to={BlogRoute.to}
+                      className="px-4 py-2 hover:bg-muted rounded-md text-center"
+                      activeProps={{
+                        className:
+                          "font-bold bg-dawn-pink-300 dark:bg-night-sky-900",
+                      }}
+                      resetScroll
+                    >
+                      Blog
+                    </Link>
+                    <Link
+                      to={ProjectsRoute.to}
+                      className="px-4 py-2 hover:bg-muted rounded-md text-center"
+                      activeProps={{
+                        className:
+                          "font-bold bg-dawn-pink-300 dark:bg-night-sky-900",
+                      }}
+                      resetScroll
+                    >
+                      Projects
+                    </Link>
+                    <Link
+                      to={AboutRoute.to}
+                      className="px-4 py-2 hover:bg-muted rounded-md text-center"
+                      activeProps={{
+                        className:
+                          "font-bold bg-dawn-pink-300 dark:bg-night-sky-900",
+                      }}
+                      resetScroll
+                    >
+                      About
+                    </Link>
+                    <div className="px-2 flex items-center justify-center">
+                      <GitHub githubLink={"https://github.com/andrew-s28/"} />
+                      <DarkModeSwitch />
                     </div>
-                    <Popover.Arrow
-                      height={10}
-                      className="dark:fill-dawn-pink-100 fill-night-sky-950"
-                    />
-                  </Popover.Content>
-                </Popover.Portal>
-              </Popover.Root>
-            </div>
+                  </div>
+                  <Popover.Arrow
+                    height={10}
+                    className="dark:fill-dawn-pink-100 fill-night-sky-950"
+                  />
+                </Popover.Content>
+              </Popover.Portal>
+            </Popover.Root>
           </div>
-        </nav>
-      )}
+        </div>
+      </nav>
     </div>
   );
 }

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
 import DarkModeSwitch from "./DarkModeSwitch";
 import GitHub from "./ui/GitHubMark";
 import { Link } from "@tanstack/react-router";
-import { useWindowSize } from "~/hooks/useWindowSize";
+import { useWidth } from "~/hooks/useWindowSize";
 import { Popover } from "radix-ui";
 import { MenuIcon, HomeIcon } from "lucide-react";
 import { Route as ProjectsRoute } from "~/routes/projects.index";
@@ -37,7 +37,7 @@ const navStyles = {
 };
 
 export default function Navbar() {
-  const { width } = useWindowSize();
+  const { width } = useWidth();
   return (
     <div className={navStyles.container}>
       {width >= 768 ? (

--- a/frontend/src/hooks/useWindowSize.tsx
+++ b/frontend/src/hooks/useWindowSize.tsx
@@ -1,9 +1,81 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
+
+export function useWidth() {
+  const [width, setWidth] = useState(10000);
+  const didMount = useRef(false);
+
+  useEffect(() => {
+    if (!didMount.current) {
+      // first width update is handled by script in the document itself, see initialTheme() below
+      const storedWidth = localStorage.getItem("innerWidth");
+      setWidth(Number(storedWidth ?? 10000));
+      didMount.current = true;
+      return;
+    }
+
+    const handleResize = () => {
+      setWidth(window.innerWidth);
+    };
+
+    window.addEventListener("resize", handleResize);
+    handleResize();
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  return { width: width };
+}
+
+export function useHeight() {
+  const [height, setHeight] = useState(10000);
+  const didMount = useRef(false);
+
+  useEffect(() => {
+    if (!didMount.current) {
+      // first height update is handled by script in the document itself, see initialWindowSize() below
+      const storedHeight = localStorage.getItem("innerHeight");
+      setHeight(Number(storedHeight ?? 10000));
+      didMount.current = true;
+      return;
+    }
+
+    const handleResize = () => {
+      setHeight(window.innerHeight);
+    };
+
+    window.addEventListener("resize", handleResize);
+    handleResize();
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  return { height: height };
+}
+
+export function initialWindowSize() {
+  // this script sets theme on DOM load, before hydration
+  // https://tanstack.com/router/latest/docs/framework/react/guide/document-head-management/#scripts
+  return {
+    children: `
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+      if (!("innerWidth" in localStorage)) {
+        localStorage.setItem("innerWidth", width);
+      }
+      if (!("innerHeight" in localStorage)) {
+        localStorage.setItem("innerHeight", height);
+      }
+    `,
+  };
+}
 
 export const useWindowSize = (debounce: boolean = false) => {
   const [height, setHeight] = useState(10000);
   const [width, setWidth] = useState(10000);
-  const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -23,7 +95,6 @@ export const useWindowSize = (debounce: boolean = false) => {
 
     window.addEventListener("resize", handleResize);
     handleResize();
-    setIsLoaded(true);
 
     return () => {
       if (timeoutId) clearTimeout(timeoutId);
@@ -31,5 +102,5 @@ export const useWindowSize = (debounce: boolean = false) => {
     };
   }, [debounce]);
 
-  return { width: width, height: height, isLoaded: isLoaded };
+  return { width: width, height: height };
 };

--- a/frontend/src/hooks/useWindowSize.tsx
+++ b/frontend/src/hooks/useWindowSize.tsx
@@ -1,26 +1,23 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 
 export function useWidth() {
-  const [width, setWidth] = useState(10000);
-  const didMount = useRef(false);
+  const [width, setWidth] = useState<number | null>(null);
 
   useEffect(() => {
-    if (!didMount.current) {
-      // first width update is handled by script in the document itself, see initialTheme() below
-      const storedWidth = localStorage.getItem("innerWidth");
-      setWidth(Number(storedWidth ?? 10000));
-      didMount.current = true;
-      return;
-    }
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
     const handleResize = () => {
-      setWidth(window.innerWidth);
+      if (timeoutId) clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => {
+        setWidth(window.innerWidth);
+      }, 300); // Adjust debounce delay as needed
     };
 
     window.addEventListener("resize", handleResize);
     handleResize();
 
     return () => {
+      if (timeoutId) clearTimeout(timeoutId);
       window.removeEventListener("resize", handleResize);
     };
   }, []);
@@ -29,48 +26,28 @@ export function useWidth() {
 }
 
 export function useHeight() {
-  const [height, setHeight] = useState(10000);
-  const didMount = useRef(false);
+  const [height, setHeight] = useState<number | null>(null);
 
   useEffect(() => {
-    if (!didMount.current) {
-      // first height update is handled by script in the document itself, see initialWindowSize() below
-      const storedHeight = localStorage.getItem("innerHeight");
-      setHeight(Number(storedHeight ?? 10000));
-      didMount.current = true;
-      return;
-    }
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
     const handleResize = () => {
-      setHeight(window.innerHeight);
+      if (timeoutId) clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => {
+        setHeight(window.innerHeight);
+      }, 300); // Adjust debounce delay as needed
     };
 
     window.addEventListener("resize", handleResize);
     handleResize();
 
     return () => {
+      if (timeoutId) clearTimeout(timeoutId);
       window.removeEventListener("resize", handleResize);
     };
   }, []);
 
   return { height: height };
-}
-
-export function initialWindowSize() {
-  // this script sets theme on DOM load, before hydration
-  // https://tanstack.com/router/latest/docs/framework/react/guide/document-head-management/#scripts
-  return {
-    children: `
-      const width = window.innerWidth;
-      const height = window.innerHeight;
-      if (!("innerWidth" in localStorage)) {
-        localStorage.setItem("innerWidth", width);
-      }
-      if (!("innerHeight" in localStorage)) {
-        localStorage.setItem("innerHeight", height);
-      }
-    `,
-  };
 }
 
 export const useWindowSize = (debounce: boolean = false) => {

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -15,6 +15,7 @@ import { seo } from "~/utils/seo";
 import { ThemeProvider, initialTheme } from "../components/ThemeProvider";
 import { MotionConfig } from "framer-motion";
 import Footer from "~/components/Footer";
+import { initialWindowSize } from "~/hooks/useWindowSize";
 
 export const Route = createRootRoute({
   head: () => ({
@@ -31,7 +32,7 @@ export const Route = createRootRoute({
         description: `Personal website and blog for physical oceanographer and software developer Andrew Scherer.`,
       }),
     ],
-    scripts: [initialTheme()],
+    scripts: [initialTheme(), initialWindowSize()],
     links: [
       { rel: "stylesheet", href: appCss },
       {

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -15,7 +15,6 @@ import { seo } from "~/utils/seo";
 import { ThemeProvider, initialTheme } from "../components/ThemeProvider";
 import { MotionConfig } from "framer-motion";
 import Footer from "~/components/Footer";
-import { initialWindowSize } from "~/hooks/useWindowSize";
 
 export const Route = createRootRoute({
   head: () => ({
@@ -32,7 +31,7 @@ export const Route = createRootRoute({
         description: `Personal website and blog for physical oceanographer and software developer Andrew Scherer.`,
       }),
     ],
-    scripts: [initialTheme(), initialWindowSize()],
+    scripts: [initialTheme()],
     links: [
       { rel: "stylesheet", href: appCss },
       {

--- a/frontend/src/routes/actions-dashboard.tsx
+++ b/frontend/src/routes/actions-dashboard.tsx
@@ -34,7 +34,6 @@ const loadRepositories = async () => {
   const workflows = await api.getWorkflows();
   const workflowRuns = await api.getWorkflowRuns();
   let repositoriesWithRuns: RepositoryWithRuns[] = [];
-  // console.log(repositories, workflows, workflowRuns);
   // Map repositories to include workflow runs
   repositoriesWithRuns = repositories.results.map((repo) => {
     const repoWorkflows = workflows.results.filter(
@@ -193,7 +192,6 @@ function RepositoryCard({ repo, onToggle }: RepositoryCardProps) {
     const hasInProgress = repo.workflows.some((workflow) =>
       workflow.runs?.some((run) => run.status === "in_progress")
     );
-    console.log(repo.workflows[0].runs);
     const allSuccess = repo.workflows.every((workflow) =>
       workflow.runs?.every(
         (run) => run.conclusion === "success" || run === undefined

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, ReactNode } from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useWindowSize } from "~/hooks/useWindowSize";
+import { useHeight, useWidth } from "~/hooks/useWindowSize";
 import { motion } from "motion/react";
 import { useIsSSR } from "~/hooks/useIsSSR";
 import hexToRgba from "hex-to-rgba";
@@ -60,7 +60,8 @@ interface StarfieldConfig {
 function Starfield({ configs }: { configs: StarfieldConfig[] }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
-  const { width, height } = useWindowSize(true);
+  const { width } = useWidth();
+  const { height } = useHeight();
   const prefersReducedMotion = usePrefersReducedMotion();
 
   const milkyWayColors = [
@@ -366,7 +367,7 @@ function Waves({
   const wavePath =
     "10 0 10-10 20-10 2.34 0 4.25 1.9 4.25 4.25 0-1.03-.84-1.87-1.88-1.87-2.1 0-3.81 1.7-3.81 3.81 0 2.1 1.71 3.81 3.81 3.81 ";
   const waveWidth = 125;
-  const { width } = useWindowSize();
+  const { width } = useWidth();
   const waveRepeat = Math.max(Math.ceil(width / waveWidth), 10);
   const path = `M0 0C10 0 10-10 20-10c2.35 0 4.25 1.9 4.25 4.25 0-1.03-.84-1.87-1.87-1.87-2.11 0-3.81 1.7-3.81 3.81 0 2.1 1.7 3.81 3.81 3.81 ${wavePath.repeat(waveRepeat)}`;
   const color = `${backgroundColor || ""} ${strokeColor || ""}`;

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -60,8 +60,10 @@ interface StarfieldConfig {
 function Starfield({ configs }: { configs: StarfieldConfig[] }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
-  const { width } = useWidth();
-  const { height } = useHeight();
+  const { width: widthInit } = useWidth();
+  const { height: heightInit } = useHeight();
+  const width = widthInit || 1920; // Fallback to 1920 if width is not available
+  const height = heightInit || 400; // Fallback to 400 if height is not available
   const prefersReducedMotion = usePrefersReducedMotion();
 
   const milkyWayColors = [
@@ -367,7 +369,8 @@ function Waves({
   const wavePath =
     "10 0 10-10 20-10 2.34 0 4.25 1.9 4.25 4.25 0-1.03-.84-1.87-1.88-1.87-2.1 0-3.81 1.7-3.81 3.81 0 2.1 1.71 3.81 3.81 3.81 ";
   const waveWidth = 125;
-  const { width } = useWidth();
+  const { width: widthInit } = useWidth();
+  const width = widthInit || 600; // Fallback to 600 if width is not available
   const waveRepeat = Math.max(Math.ceil(width / waveWidth), 10);
   const path = `M0 0C10 0 10-10 20-10c2.35 0 4.25 1.9 4.25 4.25 0-1.03-.84-1.87-1.87-1.87-2.11 0-3.81 1.7-3.81 3.81 0 2.1 1.7 3.81 3.81 3.81 ${wavePath.repeat(waveRepeat)}`;
   const color = `${backgroundColor || ""} ${strokeColor || ""}`;


### PR DESCRIPTION
Navbar state was initialized to very large screen, which meant on mobile it flashed as a squeezed navbar when page loaded. This swaps to using tailwind media queries instead, which are responsive as soon as CSS is loaded. 

Also separated useWindowSize into useWidth and useHeight so that one state update doesn't trigger useEffect on both. 